### PR TITLE
Add packet write jitter

### DIFF
--- a/cmd/conn.go
+++ b/cmd/conn.go
@@ -70,7 +70,7 @@ func newUDPAuthSession(address, sharedSecret string, mtuSize int, sendattrs, rec
 		sendattrs[radius.AttributeTypeNasIdentifier] = []string{"radius-client"}
 	}
 	sendattrs[radius.AttributeTypeFramedMtu] = []string{strconv.Itoa(mtuSize)}
-	return radius.NewAuthenticationSession(conn, sharedSecret, udpTimeout, maxWriteJitter, udpRetries, mtuSize, sendattrs, recvattrs)
+	return radius.NewAuthenticationSession(conn, sharedSecret, udpTimeout, minWriteJitter, maxWriteJitter, udpRetries, mtuSize, sendattrs, recvattrs)
 }
 
 func newUDPAcctSession(address, sharedSecret string, mtuSize int, sendattrs, recvattrs radius.AttributeMap) (*radius.AccountingSession, error) {
@@ -82,7 +82,7 @@ func newUDPAcctSession(address, sharedSecret string, mtuSize int, sendattrs, rec
 		sendattrs[radius.AttributeTypeNasIdentifier] = []string{"radius-client"}
 	}
 	sendattrs[radius.AttributeTypeFramedMtu] = []string{strconv.Itoa(mtuSize)}
-	return radius.NewAccountingSession(conn, sharedSecret, udpTimeout, maxWriteJitter, udpRetries, mtuSize, sendattrs, recvattrs)
+	return radius.NewAccountingSession(conn, sharedSecret, udpTimeout, minWriteJitter, maxWriteJitter, udpRetries, mtuSize, sendattrs, recvattrs)
 }
 
 func newTLSAuthSession(address, serverCA, clientCer string, sendattrs, recvattrs radius.AttributeMap) (*radius.AuthenticationSession, error) {
@@ -93,7 +93,7 @@ func newTLSAuthSession(address, serverCA, clientCer string, sendattrs, recvattrs
 	if _, ok := sendattrs[radius.AttributeTypeNasIdentifier]; !ok {
 		sendattrs[radius.AttributeTypeNasIdentifier] = []string{"radius-client"}
 	}
-	return radius.NewAuthenticationSession(conn, "radsec", tlsTimeout, maxWriteJitter, 1, radius.DatagramMaxLen, sendattrs, recvattrs)
+	return radius.NewAuthenticationSession(conn, "radsec", tlsTimeout, minWriteJitter, maxWriteJitter, 1, radius.DatagramMaxLen, sendattrs, recvattrs)
 }
 
 func newTLSAcctSession(address, serverCA, clientCer string, sendattrs, recvattrs radius.AttributeMap) (*radius.AccountingSession, error) {
@@ -104,5 +104,5 @@ func newTLSAcctSession(address, serverCA, clientCer string, sendattrs, recvattrs
 	if _, ok := sendattrs[radius.AttributeTypeNasIdentifier]; !ok {
 		sendattrs[radius.AttributeTypeNasIdentifier] = []string{"radius-client"}
 	}
-	return radius.NewAccountingSession(conn, "radsec", tlsTimeout, maxWriteJitter, 1, radius.DatagramMaxLen, sendattrs, recvattrs)
+	return radius.NewAccountingSession(conn, "radsec", tlsTimeout, minWriteJitter, maxWriteJitter, 1, radius.DatagramMaxLen, sendattrs, recvattrs)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,8 @@ var (
 	tcpPort           int
 	tlsTimeoutStr     string
 	tlsTimeout        time.Duration
+	minWriteJitterStr string
+	minWriteJitter    time.Duration
 	maxWriteJitterStr string
 	maxWriteJitter    time.Duration
 	radsecUnsafe      bool
@@ -80,9 +82,16 @@ for most common authentication protocol.`,
 		if err != nil {
 			return fmt.Errorf("invalid TLS timeout: %w", err)
 		}
+		minWriteJitter, err = time.ParseDuration(minWriteJitterStr)
+		if err != nil {
+			return fmt.Errorf("invalid min write jitter: %w", err)
+		}
 		maxWriteJitter, err = time.ParseDuration(maxWriteJitterStr)
 		if err != nil {
 			return fmt.Errorf("invalid max write jitter: %w", err)
+		}
+		if minWriteJitter > maxWriteJitter {
+			return fmt.Errorf("max write jitter must be greater than min write jitter")
 		}
 
 		return nil
@@ -107,6 +116,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&tcpPort, "tcp-port", radius.RadSecTCPPort, "RADIUS/TLS (RadSec) port")
 	rootCmd.PersistentFlags().BoolVar(&radsecUnsafe, "radsec-unsafe", false, "RADIUS/TLS (RadSec) skip server authentication")
 	rootCmd.PersistentFlags().StringVar(&tlsTimeoutStr, "tls-timeout", "15s", "RADIUS/TLS connection response timeout")
+	rootCmd.PersistentFlags().StringVar(&minWriteJitterStr, "min-send-jitter", "50ms", "Min packet send time-in-between jitter")
 	rootCmd.PersistentFlags().StringVar(&maxWriteJitterStr, "max-send-jitter", "1s", "Max packet send time-in-between jitter")
 	rootCmd.PersistentFlags().StringArray("attrs-to-send", []string{}, `Additional attributes to send. Attributes will be
 overwritten if required by protocol executed. Each

--- a/src/radius/accounting_session.go
+++ b/src/radius/accounting_session.go
@@ -16,8 +16,8 @@ type AccountingSession struct {
 	session
 }
 
-func NewAccountingSession(conn net.Conn, ss string, timeout, maxWriteJitter time.Duration, retries, mtuSize int, sendattrsMap, recvattrsMap AttributeMap) (*AccountingSession, error) {
-	session, err := newSession(conn, ss, timeout, maxWriteJitter, retries, mtuSize, sendattrsMap, recvattrsMap)
+func NewAccountingSession(conn net.Conn, ss string, timeout, minWriteJitter, maxWriteJitter time.Duration, retries, mtuSize int, sendattrsMap, recvattrsMap AttributeMap) (*AccountingSession, error) {
+	session, err := newSession(conn, ss, timeout, minWriteJitter, maxWriteJitter, retries, mtuSize, sendattrsMap, recvattrsMap)
 	if err != nil {
 		return nil, err
 	}

--- a/src/radius/authentication_session.go
+++ b/src/radius/authentication_session.go
@@ -18,8 +18,8 @@ type AuthenticationSession struct {
 	session
 }
 
-func NewAuthenticationSession(conn net.Conn, ss string, timeout, maxWriteJitter time.Duration, retries, mtuSize int, sendattrsMap, recvattrsMap AttributeMap) (*AuthenticationSession, error) {
-	session, err := newSession(conn, ss, timeout, maxWriteJitter, retries, mtuSize, sendattrsMap, recvattrsMap)
+func NewAuthenticationSession(conn net.Conn, ss string, timeout, minWriteJitter, maxWriteJitter time.Duration, retries, mtuSize int, sendattrsMap, recvattrsMap AttributeMap) (*AuthenticationSession, error) {
+	session, err := newSession(conn, ss, timeout, minWriteJitter, maxWriteJitter, retries, mtuSize, sendattrsMap, recvattrsMap)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Could be set to 0s, but useful to simulate a non-perfect scenario where
client may take some time between each packet.
